### PR TITLE
Jjorgeb/disable youtube livestream

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ To enable [Youtube API](https://developers.google.com/youtube/v3/guides/auth/ser
     GOOGLE_JAVASCRIPT_ORIGINS = AUTH_TOKENS.get('GOOGLE_JAVASCRIPT_ORIGINS', [])
     EOLZOOM_YOUTUBE_TIMEZONE = AUTH_TOKENS.get('EOLZOOM_YOUTUBE_TIMEZONE', '')
 
+# Enable/Disable Youtube Livestreams
+
+Youtube livestreams are enabled by default, but they can be disabled by setting the variable ENABLE_YOUTUBE_LIVESTREAMING to false in lms.yml and cms.yml.
+
+    ENABLE_YOUTUBE_LIVESTREAMING = false
+
 ## TESTS
 **Prepare tests:**
 

--- a/eolzoom/eolzoom.py
+++ b/eolzoom/eolzoom.py
@@ -200,6 +200,7 @@ class EolZoomXBlock(XBlock):
             'url_new_livebroadcast': reverse('url_new_livebroadcast'),
             'url_update_livebroadcast': reverse('url_update_livebroadcast'),
             'url_update_meeting': reverse('update_scheduled_meeting'),
+            'enable_youtube_livestreaming': DJANGO_SETTINGS.ENABLE_YOUTUBE_LIVESTREAMING,
         }
         frag.initialize_js('EolZoomStudioXBlock', json_args=settings)
         return frag 
@@ -281,6 +282,7 @@ class EolZoomXBlock(XBlock):
                 self.xmodule_runtime,
                 'user_is_staff',
                 False),
+            'enable_youtube_livestreaming': DJANGO_SETTINGS.ENABLE_YOUTUBE_LIVESTREAMING,
         }
 
     def render_template(self, template_path, context):

--- a/eolzoom/settings/common.py
+++ b/eolzoom/settings/common.py
@@ -14,3 +14,4 @@ def plugin_settings(settings):
     settings.GOOGLE_REDIRECT_URIS = []
     settings.GOOGLE_JAVASCRIPT_ORIGINS = []
     settings.EOLZOOM_YOUTUBE_TIMEZONE = ''
+    settings.ENABLE_YOUTUBE_LIVESTREAMING = True

--- a/eolzoom/static/html/author_view.html
+++ b/eolzoom/static/html/author_view.html
@@ -20,7 +20,7 @@
             <p>El anfitrión de la transmisión es: <strong>{{xblock.created_by}}</strong>.</p>
         </div>
         <div class="alert alert-info">
-            <p>IMPORTANTE: Las modificaciones realizadas a través del sitio <a href="{{ EOLZOOM_DOMAIN }}">UChile Zoom</a> no se verán reflejadas en este componente.</p>
+            <p>IMPORTANTE: Las modificaciones realizadas a través del sitio <a href="{{ EOLZOOM_DOMAIN }}">Zoom</a> no se verán reflejadas en este componente.</p>
             <p>ATENCIÓN: Sólo <strong>{{xblock.created_by}}</strong> podrá modificar este componente e iniciar la transmisión.</p>
         </div>
         {% if xblock.google_access %}

--- a/eolzoom/static/html/studio.html
+++ b/eolzoom/static/html/studio.html
@@ -56,6 +56,7 @@
       </div>
       <span class="tip setting-help">Duración de la videollamada (en minutos)</span>
     </li>
+    {% if enable_youtube_livestreaming %}
     <li class="field comp-setting-entry is-set">
       <div class="wrapper-comp-setting">
         <label class="label setting-label" for="google_access">Youtube Livestream</label>
@@ -78,6 +79,7 @@
         <input hidden name="youtube_logged" type="text" value="0">
       </span>
     </li>
+    {% endif %}
     <li class="field comp-setting-entry is-set">
       <div class="wrapper-comp-setting">
         <label class="label setting-label" for="restricted_access">Acceso Restringido</label>

--- a/eolzoom/static/js/src/studio.js
+++ b/eolzoom/static/js/src/studio.js
@@ -17,18 +17,25 @@ function EolZoomStudioXBlock(runtime, element, settings) {
         var email_notification = $(element).find('#email_notification').val();
         restricted_access = restricted_access == '1';
         email_notification = email_notification == '1';
-        var google_access = $(element).find('#google_access').val();
-        var youtube_permission_enabled = $(element).find('input[name=youtube_permission_enabled]').val();
+        if(enable_youtube_livestreaming) {
+            var google_access = $(element).find('#google_access').val();
+            var youtube_permission_enabled = $(element).find('input[name=youtube_permission_enabled]').val();
+        }
+        else {
+            var google_access = 0;
+        }
         google_access = google_access == '1';
         if(display_name == "" || date == "" || time == "" || duration < 0 || duration == "") {
             alert("Datos inválidos. Revisa nuevamente la información ingresada");
             e.preventDefault();
             return;
         }
-        if(youtube_permission_enabled != "1" && google_access) {
+        if(enable_youtube_livestreaming) {
+            if(youtube_permission_enabled != "1" && google_access) {
             alert("Permisos insuficientes con la cuenta de Google o Zoom asociada");
             e.preventDefault();
             return;
+            }
         }
         form_data.append('display_name', display_name);
         form_data.append('description', description);


### PR DESCRIPTION
Se agrega una setting para poder deshabilitar los youtube livestreams en la vista de studio y que no se muestre esta opcion en los settings del bloque. Esto permite que sea posible ocultar esta opcion en plataformas en donde no funcionan los livestreams, como norteamericanos.
Ademas se borra una referencia a Uchile.
